### PR TITLE
Move min_weight_parameter to ros server

### DIFF
--- a/global_segment_map_node/cfg/tango.yaml
+++ b/global_segment_map_node/cfg/tango.yaml
@@ -16,3 +16,5 @@ voxels_per_side: 8
 truncation_distance_factor: 5.0
 voxel_carving_enabled: false
 max_ray_length_m: 2.5
+mesh_config:
+  min_weight: 0.0001

--- a/global_segment_map_node/include/voxblox_gsm/conversions.h
+++ b/global_segment_map_node/include/voxblox_gsm/conversions.h
@@ -52,12 +52,13 @@ inline void voxelEvaluationDetails2VoxelEvaluationDetailsMsg(
 
 inline void convertVoxelGridToPointCloud(
     const voxblox::Layer<voxblox::TsdfVoxel>& tsdf_voxels,
+    const MeshIntegratorConfig& mesh_config,
     pcl::PointCloud<pcl::PointSurfel>* surfel_cloud) {
   CHECK_NOTNULL(surfel_cloud);
 
   static constexpr bool kConnectedMesh = false;
   voxblox::Mesh mesh;
-  io::convertLayerToMesh(tsdf_voxels, &mesh, kConnectedMesh);
+  io::convertLayerToMesh(tsdf_voxels, mesh_config, &mesh, kConnectedMesh);
 
   surfel_cloud->reserve(mesh.vertices.size());
 

--- a/global_segment_map_node/src/controller.cpp
+++ b/global_segment_map_node/src/controller.cpp
@@ -669,9 +669,11 @@ bool Controller::publishObjects(const bool publish_all) {
     CHECK_EQ(origin_shifted_tsdf_layer_W, origin_shifted_label_layer_W);
 
     // Extract surfel cloud from layer.
+    MeshIntegratorConfig mesh_config;
+    node_handle_private_->param<float>("mesh_config/min_weight", mesh_config.min_weight, mesh_config.min_weight);
     pcl::PointCloud<pcl::PointSurfel>::Ptr surfel_cloud(
         new pcl::PointCloud<pcl::PointSurfel>());
-    convertVoxelGridToPointCloud(tsdf_layer, surfel_cloud.get());
+    convertVoxelGridToPointCloud(tsdf_layer, mesh_config, surfel_cloud.get());
 
     if (surfel_cloud->empty()) {
       LOG(WARNING) << "Labelled segment does not contain enough data to "


### PR DESCRIPTION
When gsm_updates are serialized to ros msgs, the parameter MeshIntegratorConfig::min_weight is used. When converting the ros_msg back to a GsmUpdate, this same parameter is used. If different values are used for serialization and deserialization (for example in different nodes), this can lead to undesired behaviour.
 * the MeshIntegratorConfig::min_weight Parameter is now loaded from the ros parameter server (if present) and used for serialization. This way, the same value can be used for deserialization in a different node and becomes easily adjustable.