### PR TITLE
Fix/concurrency

### DIFF
--- a/global_segment_map_node/include/voxblox_gsm/controller.h
+++ b/global_segment_map_node/include/voxblox_gsm/controller.h
@@ -73,11 +73,6 @@ class Controller {
   bool extractInstancesCallback(std_srvs::Empty::Request& request,
                                 std_srvs::Empty::Response& response);
 
-  virtual void extractSegmentLayers(
-      const std::vector<Label>& labels,
-      std::unordered_map<Label, LayerPair>* label_layers_map,
-      bool labels_list_is_complete = false);
-
   bool lookupTransform(const std::string& from_frame,
                        const std::string& to_frame, const ros::Time& timestamp,
                        Transformation* transform);

--- a/global_segment_map_node/include/voxblox_gsm/controller.h
+++ b/global_segment_map_node/include/voxblox_gsm/controller.h
@@ -81,9 +81,6 @@ class Controller {
 
   void updateMeshEvent(const ros::TimerEvent& e);
 
-  virtual void getLabelsToPublish(const bool get_all,
-                                  std::vector<Label>* labels);
-
   void computeAlignedBoundingBox(
       const pcl::PointCloud<pcl::PointSurfel>::Ptr surfel_cloud,
       Eigen::Vector3f* bbox_translation, Eigen::Quaternionf* bbox_quaternion,

--- a/global_segment_map_node/include/voxblox_gsm/iodb_controller.h
+++ b/global_segment_map_node/include/voxblox_gsm/iodb_controller.h
@@ -76,6 +76,9 @@ class IodbController : public Controller {
       modelify_msgs::ValidateMergedObject::Request& request,
       modelify_msgs::ValidateMergedObject::Response& response);
 
+  virtual void getLabelsToPublish(const bool get_all,
+                                  std::vector<Label>* labels);
+
   virtual void publishGsmUpdate(const ros::Publisher& publisher,
                                 modelify_msgs::GsmUpdate* gsm_update);
 

--- a/global_segment_map_node/include/voxblox_gsm/iodb_controller.h
+++ b/global_segment_map_node/include/voxblox_gsm/iodb_controller.h
@@ -46,7 +46,7 @@ class IodbController : public Controller {
   void validateMergedObjectService(
       ros::ServiceServer* validate_merged_object_srv);
 
-  virtual void extractSegmentLayers(
+  void extractSegmentLayers(
       const std::vector<Label>& labels,
       std::unordered_map<Label, LayerTuple>* label_layers_map,
       bool labels_list_is_complete = false);

--- a/global_segment_map_node/include/voxblox_gsm/sliding_window_controller.h
+++ b/global_segment_map_node/include/voxblox_gsm/sliding_window_controller.h
@@ -22,7 +22,7 @@ class SlidingWindowController : public IodbController {
   void extractSegmentLayers(
       const std::vector<Label>& labels,
       std::unordered_map<Label, LayerPair>* label_layers_map,
-      bool labels_list_is_complete = false) override;
+      bool labels_list_is_complete = false);
 
  private:
   /**

--- a/global_segment_map_node/launch/gsm.launch
+++ b/global_segment_map_node/launch/gsm.launch
@@ -2,7 +2,7 @@
   <arg name="gsm_node_params_file" default="$(find gsm_node)/cfg/default.yaml"/>
   <arg name="sensor_topics_file" default="$(find depth_segmentation)/cfg/default_topics.yaml"/>
 
-  <node name="gsm_node" pkg="gsm_node" type="gsm_node" output="log">
+  <node name="gsm_node" pkg="gsm_node" type="gsm_node" output="log" launch-prefix="xterm -e gdb --args">
     <rosparam command="load" file="$(arg sensor_topics_file)" />
     <rosparam command="load" file="$(arg gsm_node_params_file)" />
   </node>

--- a/global_segment_map_node/launch/gsm.launch
+++ b/global_segment_map_node/launch/gsm.launch
@@ -2,7 +2,7 @@
   <arg name="gsm_node_params_file" default="$(find gsm_node)/cfg/default.yaml"/>
   <arg name="sensor_topics_file" default="$(find depth_segmentation)/cfg/default_topics.yaml"/>
 
-  <node name="gsm_node" pkg="gsm_node" type="gsm_node" output="log" launch-prefix="xterm -e gdb --args">
+  <node name="gsm_node" pkg="gsm_node" type="gsm_node" output="log">
     <rosparam command="load" file="$(arg sensor_topics_file)" />
     <rosparam command="load" file="$(arg gsm_node_params_file)" />
   </node>

--- a/global_segment_map_node/src/controller.cpp
+++ b/global_segment_map_node/src/controller.cpp
@@ -543,14 +543,18 @@ bool Controller::generateMeshCallback(
 
 bool Controller::saveSegmentsAsMeshCallback(
     std_srvs::Empty::Request& request, std_srvs::Empty::Response& response) {
-  // Get list of all labels in the map.
-  Labels labels = map_->getLabelList();
-  static constexpr bool kConnectedMesh = false;
-
+  Labels labels;
   std::unordered_map<Label, LabelTsdfMap::LayerPair> label_to_layers;
-  // Extract the TSDF and label layers corresponding to a segment.
-  constexpr bool kLabelsListIsComplete = false;
-  map_->extractSegmentLayers(labels, &label_to_layers, kLabelsListIsComplete);
+  {
+    std::lock_guard<std::mutex> label_tsdf_layers_lock(
+        label_tsdf_layers_mutex_);
+    // Get list of all labels in the map.
+    labels = map_->getLabelList();
+
+    // Extract the TSDF and label layers corresponding to each segment.
+    constexpr bool kLabelsListIsComplete = true;
+    map_->extractSegmentLayers(labels, &label_to_layers, kLabelsListIsComplete);
+  }
 
   const char* kSegmentFolder = "gsm_segments";
 
@@ -587,87 +591,21 @@ bool Controller::saveSegmentsAsMeshCallback(
   return overall_success;
 }
 
-void Controller::extractSegmentLayers(
-    const std::vector<Label>& labels,
-    std::unordered_map<Label, LayerPair>* label_layers_map,
-    bool labels_list_is_complete) {
-  CHECK(label_layers_map);
-
-  // Build map from labels to tsdf and label layers. Each will contain the
-  // segment of the corresponding layer.
-  Layer<TsdfVoxel> tsdf_layer_empty(map_config_.voxel_size,
-                                    map_config_.voxels_per_side);
-  Layer<LabelVoxel> label_layer_empty(map_config_.voxel_size,
-                                      map_config_.voxels_per_side);
-
-  for (const Label& label : labels) {
-    label_layers_map->emplace(
-        label, std::make_pair(tsdf_layer_empty, label_layer_empty));
-  }
-
-  BlockIndexList all_label_blocks;
-  map_->getTsdfLayerPtr()->getAllAllocatedBlocks(&all_label_blocks);
-
-  for (const BlockIndex& block_index : all_label_blocks) {
-    Block<TsdfVoxel>::Ptr global_tsdf_block =
-        map_->getTsdfLayerPtr()->getBlockPtrByIndex(block_index);
-    Block<LabelVoxel>::Ptr global_label_block =
-        map_->getLabelLayerPtr()->getBlockPtrByIndex(block_index);
-
-    const size_t vps = global_label_block->voxels_per_side();
-    for (size_t i = 0; i < vps * vps * vps; ++i) {
-      const LabelVoxel& global_label_voxel =
-          global_label_block->getVoxelByLinearIndex(i);
-
-      if (global_label_voxel.label == 0u) {
-        continue;
-      }
-
-      auto it = label_layers_map->find(global_label_voxel.label);
-      if (it == label_layers_map->end()) {
-        if (labels_list_is_complete) {
-          LOG(FATAL) << "At least one voxel in the GSM is assigned to label "
-                     << global_label_voxel.label
-                     << " which is not in the given "
-                        "list of labels to retrieve.";
-        }
-        continue;
-      }
-
-      Layer<TsdfVoxel>& tsdf_layer = it->second.first;
-      Layer<LabelVoxel>& label_layer = it->second.second;
-
-      Block<TsdfVoxel>::Ptr tsdf_block =
-          tsdf_layer.allocateBlockPtrByIndex(block_index);
-      Block<LabelVoxel>::Ptr label_block =
-          label_layer.allocateBlockPtrByIndex(block_index);
-
-      CHECK(tsdf_block);
-      CHECK(label_block);
-
-      TsdfVoxel& tsdf_voxel = tsdf_block->getVoxelByLinearIndex(i);
-      LabelVoxel& label_voxel = label_block->getVoxelByLinearIndex(i);
-
-      const TsdfVoxel& global_tsdf_voxel =
-          global_tsdf_block->getVoxelByLinearIndex(i);
-
-      tsdf_voxel = global_tsdf_voxel;
-      label_voxel = global_label_voxel;
-    }
-  }
-}
-
 bool Controller::extractInstancesCallback(std_srvs::Empty::Request& request,
                                           std_srvs::Empty::Response& response) {
-  // Get list of all instances in the map.
-  InstanceLabels instance_labels = map_->getInstanceList();
-  static constexpr bool kConnectedMesh = false;
-
+  InstanceLabels instance_labels;
   std::unordered_map<InstanceLabel, LabelTsdfMap::LayerPair>
       instance_label_to_layers;
-  // Extract the TSDF and label layers corresponding to a segment.
-  constexpr bool kLabelsListIsComplete = true;
-  map_->extractInstanceLayers(instance_labels, &instance_label_to_layers);
+  {
+    std::lock_guard<std::mutex> label_tsdf_layers_lock(
+        label_tsdf_layers_mutex_);
+    // Get list of all instances in the map.
+    instance_labels = map_->getInstanceList();
+
+    // Extract the TSDF and label layers corresponding to each instance segment.
+    constexpr bool kLabelsListIsComplete = true;
+    map_->extractInstanceLayers(instance_labels, &instance_label_to_layers);
+  }
 
   for (const InstanceLabel instance_label : instance_labels) {
     auto it = instance_label_to_layers.find(instance_label);

--- a/global_segment_map_node/src/controller.cpp
+++ b/global_segment_map_node/src/controller.cpp
@@ -634,17 +634,6 @@ bool Controller::extractInstancesCallback(std_srvs::Empty::Request& request,
   return true;
 }
 
-void Controller::getLabelsToPublish(const bool get_all,
-                                    std::vector<Label>* labels) {
-  CHECK_NOTNULL(labels);
-  if (get_all) {
-    *labels = map_->getLabelList();
-    ROS_INFO("Publishing all segments");
-  } else {
-    *labels = segment_labels_to_publish_;
-  }
-}
-
 bool Controller::lookupTransform(const std::string& from_frame,
                                  const std::string& to_frame,
                                  const ros::Time& timestamp,

--- a/global_segment_map_node/src/iodb_controller.cpp
+++ b/global_segment_map_node/src/iodb_controller.cpp
@@ -223,6 +223,17 @@ void IodbController::extractSegmentLayers(
   }
 }
 
+void IodbController::getLabelsToPublish(const bool get_all,
+                                        std::vector<Label>* labels) {
+  CHECK_NOTNULL(labels);
+  if (get_all) {
+    *labels = map_->getLabelList();
+    ROS_INFO("Publishing all segments");
+  } else {
+    *labels = segment_labels_to_publish_;
+  }
+}
+
 // TODO(ff): Create this somewhere:
 // void serializeGsmAsMsg(const map&, const label&, const parent_labels&,
 // msg*);

--- a/global_segment_map_node/src/sliding_window_controller.cpp
+++ b/global_segment_map_node/src/sliding_window_controller.cpp
@@ -147,7 +147,7 @@ void SlidingWindowController::publishWindowTrajectory(const Point& position) {
 void SlidingWindowController::getLabelsToPublish(const bool get_all,
                                                  std::vector<Label>* labels) {
   CHECK_NOTNULL(labels);
-  Controller::getLabelsToPublish(get_all, labels);
+  IodbController::getLabelsToPublish(get_all, labels);
   for (const Label& label : removed_segments_) {
     labels->erase(std::remove(labels->begin(), labels->end(), label));
   }

--- a/global_segment_map_node/src/sliding_window_controller.cpp
+++ b/global_segment_map_node/src/sliding_window_controller.cpp
@@ -67,7 +67,8 @@ void SlidingWindowController::extractSegmentLayers(
   if (!label_to_layers_.empty()) {
     *label_layers_map = label_to_layers_;
   } else {
-    extractSegmentLayers(labels, label_layers_map, labels_list_is_complete);
+    map_->extractSegmentLayers(labels, label_layers_map,
+                               labels_list_is_complete);
   }
 }
 


### PR DESCRIPTION
Builds on top of #47 to fix potential data racing in function accessing the TSDF and Label layers such as publishObjects(), publishScene(), saveSegmentsAsMeshCallback(), etc.