### PR TITLE
Temporarily add deps for minkindr_python

### DIFF
--- a/voxblox-plusplus_https.rosinstall
+++ b/voxblox-plusplus_https.rosinstall
@@ -26,6 +26,12 @@
     local-name: minkindr
     uri: https://github.com/ethz-asl/minkindr.git
 - git:
+    local-name: catkin_boost_python_buildtool
+    uri: https://github.com/ethz-asl/catkin_boost_python_buildtool
+- git:
+    local-name: numpy_eigen
+    uri: https://github.com/ethz-asl/numpy_eigen.git
+- git:
     local-name: modelify_msgs
     uri: https://github.com/ethz-asl/modelify_msgs.git
 - git:

--- a/voxblox-plusplus_ssh.rosinstall
+++ b/voxblox-plusplus_ssh.rosinstall
@@ -26,6 +26,12 @@
     local-name: minkindr
     uri: git@github.com:ethz-asl/minkindr.git
 - git:
+    local-name: catkin_boost_python_buildtool
+    uri: git@github.com:ethz-asl/catkin_boost_python_buildtool.git
+- git:
+    local-name: numpy_eigen
+    uri: git@github.com:ethz-asl/numpy_eigen.git
+- git:
     local-name: modelify_msgs
     uri: git@github.com:ethz-asl/modelify_msgs.git
 - git:


### PR DESCRIPTION
Adding build dependencies for `minkindr_python`, at least until https://github.com/ethz-asl/minkindr/issues/69 is resolved.