### PR TITLE
Service to get list of semantic instances

### DIFF
--- a/global_segment_map/include/global_segment_map/label_tsdf_map.h
+++ b/global_segment_map/include/global_segment_map/label_tsdf_map.h
@@ -68,6 +68,10 @@ class LabelTsdfMap {
   // for which the voxel count is greater than 0.
   InstanceLabels getInstanceList();
 
+  // Get the list of semantic categories of all instances
+  // for which the voxel count is greated than 0.
+  SemanticLabels getSemanticInstanceList();
+
   /**
    * Extracts separate tsdf and label layers from the gsm, for every given
    * label.

--- a/global_segment_map_node/include/voxblox_gsm/controller.h
+++ b/global_segment_map_node/include/voxblox_gsm/controller.h
@@ -13,6 +13,7 @@
 #include <global_segment_map/label_voxel.h>
 #include <global_segment_map/meshing/label_tsdf_mesh_integrator.h>
 #include <global_segment_map/utils/visualizer.h>
+#include <gsm_node/GetListSemanticInstances.h>
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <std_srvs/Empty.h>
@@ -48,6 +49,9 @@ class Controller {
   void advertiseExtractInstancesService(
       ros::ServiceServer* extract_instances_srv);
 
+  void advertiseGetListSemanticInstancesService(
+      ros::ServiceServer* get_list_semantic_categories_srv);
+
   bool enable_semantic_instance_segmentation_;
 
   bool publish_scene_mesh_;
@@ -72,6 +76,10 @@ class Controller {
 
   bool extractInstancesCallback(std_srvs::Empty::Request& request,
                                 std_srvs::Empty::Response& response);
+
+  bool getListSemanticInstancesCallback(
+      gsm_node::GetListSemanticInstances::Request& /* request */,
+      gsm_node::GetListSemanticInstances::Response& response);
 
   bool lookupTransform(const std::string& from_frame,
                        const std::string& to_frame, const ros::Time& timestamp,

--- a/global_segment_map_node/package.xml
+++ b/global_segment_map_node/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gsm_node</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Voxblox++ ROS interface</description>
 
   <author email="margarita.grinvald@mavt.ethz.ch">Margarita Grinvald</author>
@@ -20,17 +20,19 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
 
   <depend>gflags_catkin</depend>
+  <depend>global_segment_map</depend>
+  <depend>global_feature_map</depend>
   <depend>glog_catkin</depend>
+  <depend>message_generation</depend>
+  <depend>message_runtime</depend>
   <depend>minkindr_conversions</depend>
   <depend>modelify_msgs</depend>
+  <depend>opencv3_catkin</depend>
   <depend>pcl_catkin</depend>
   <depend>pcl_conversions</depend>
   <depend>roscpp</depend>
+  <depend>std_msgs</depend>
   <depend>voxblox</depend>
-  <depend>global_segment_map</depend>
-  <depend>global_feature_map</depend>
   <depend>voxblox_msgs</depend>
   <depend>voxblox_ros</depend>
-  <depend>opencv3_catkin</depend>
-
 </package>

--- a/global_segment_map_node/src/controller.cpp
+++ b/global_segment_map_node/src/controller.cpp
@@ -367,6 +367,14 @@ void Controller::advertiseExtractInstancesService(
       "extract_instances", &Controller::extractInstancesCallback, this);
 }
 
+void Controller::advertiseGetListSemanticInstancesService(
+    ros::ServiceServer* get_list_semantic_instances_srv) {
+  CHECK_NOTNULL(get_list_semantic_instances_srv);
+  *get_list_semantic_instances_srv = node_handle_private_->advertiseService(
+      "get_list_semantic_instances",
+      &Controller::getListSemanticInstancesCallback, this);
+}
+
 void Controller::processSegment(
     const sensor_msgs::PointCloud2::Ptr& segment_point_cloud_msg) {
   // Look up transform from camera frame to world frame.
@@ -589,6 +597,21 @@ bool Controller::saveSegmentsAsMeshCallback(
   }
 
   return overall_success;
+}
+
+bool Controller::getListSemanticInstancesCallback(
+    gsm_node::GetListSemanticInstances::Request& /* request */,
+    gsm_node::GetListSemanticInstances::Response& response) {
+  SemanticLabels semantic_labels;
+
+  // Get the semantic class of each recognized instance in the map.
+  semantic_labels = map_->getSemanticInstanceList();
+
+  // Map class id to human-readable label.
+  for (const SemanticLabel semantic_label : semantic_labels) {
+    response.semantic_categories.push_back(classes[(unsigned)semantic_label]);
+  }
+  return true;
 }
 
 bool Controller::extractInstancesCallback(std_srvs::Empty::Request& request,

--- a/global_segment_map_node/src/node.cpp
+++ b/global_segment_map_node/src/node.cpp
@@ -40,8 +40,11 @@ int main(int argc, char** argv) {
   controller->advertiseSaveSegmentsAsMeshService(&save_segments_as_mesh_srv);
 
   ros::ServiceServer extract_instances_srv;
+  ros::ServiceServer get_list_semantic_instances_srv;
   if (controller->enable_semantic_instance_segmentation_) {
     controller->advertiseExtractInstancesService(&extract_instances_srv);
+    controller->advertiseGetListSemanticInstancesService(
+        &get_list_semantic_instances_srv);
   }
 
   // Spinner that uses a number of threads equal to the number of cores.

--- a/global_segment_map_node/srv/GetListSemanticInstances.srv
+++ b/global_segment_map_node/srv/GetListSemanticInstances.srv
@@ -1,0 +1,2 @@
+---
+string[] semantic_categories


### PR DESCRIPTION
Added a service to query the list of semantic instances in the map.

Namely, for all recognized instances in the scene the service returns an array of strings where each string is a human-readable label of the corresponding semantic class.

Also alphabetically reordered packages in package.xml