### PR TITLE
Feature/publish selected object cloud

### DIFF
--- a/global_segment_map/include/global_segment_map/label_tsdf_map.h
+++ b/global_segment_map/include/global_segment_map/label_tsdf_map.h
@@ -68,6 +68,10 @@ class LabelTsdfMap {
   // for which the voxel count is greater than 0.
   InstanceLabels getInstanceList();
 
+  // Get the list of semantic categories of all instances
+  // for which the voxel count is greated than 0.
+  SemanticLabels getSemanticInstanceList();
+
   /**
    * Extracts separate tsdf and label layers from the gsm, for every given
    * label.

--- a/global_segment_map/include/global_segment_map/label_tsdf_map.h
+++ b/global_segment_map/include/global_segment_map/label_tsdf_map.h
@@ -62,15 +62,19 @@ class LabelTsdfMap {
 
   // Get the list of all labels
   // for which the voxel count is greater than 0.
+  // NOT THREAD SAFE.
   Labels getLabelList();
 
   // Get the list of all instance labels
   // for which the voxel count is greater than 0.
+  // NOT THREAD SAFE.
   InstanceLabels getInstanceList();
 
   // Get the list of semantic categories of all instances
   // for which the voxel count is greated than 0.
-  SemanticLabels getSemanticInstanceList();
+  // NOT THREAD SAFE.
+  void getSemanticInstanceList(InstanceLabels* instance_labels,
+                               SemanticLabels* semantic_labels);
 
   /**
    * Extracts separate tsdf and label layers from the gsm, for every given

--- a/global_segment_map/src/label_tsdf_map.cc
+++ b/global_segment_map/src/label_tsdf_map.cc
@@ -36,9 +36,8 @@ InstanceLabels LabelTsdfMap::getInstanceList() {
   return instance_labels;
 }
 
-SemanticLabels LabelTsdfMap::getSemanticInstanceList() {
-  SemanticLabels semantic_labels;
-
+void LabelTsdfMap::getSemanticInstanceList(InstanceLabels* instance_labels,
+                                           SemanticLabels* semantic_labels) {
   std::set<InstanceLabel> instance_labels_set;
   Labels labels = getLabelList();
 
@@ -52,19 +51,19 @@ SemanticLabels LabelTsdfMap::getSemanticInstanceList() {
     // If the label maps to an instance,
     // fetch the corresponding semantic class.
     if (instance_label != 0u) {
-      // As multiple labels can match to a same instance_label, make sure to
-      // only add once the semantic class of an instance_label.
+      // As multiple labels can match to a same instance_label,
+      // make sure to only add once each instance_label.
       auto ret = instance_labels_set.emplace(instance_label);
       if (ret.second) {
         SemanticLabel semantic_label =
             semantic_instance_label_fusion_.getSemanticLabel(label);
         CHECK_NE(semantic_label, 0u)
             << "Instance assigned to semantic category BACKGROUND.";
-        semantic_labels.push_back(semantic_label);
+        instance_labels->push_back(instance_label);
+        semantic_labels->push_back(semantic_label);
       }
     }
   }
-  return semantic_labels;
 }
 
 void LabelTsdfMap::extractSegmentLayers(

--- a/global_segment_map/src/meshing/label_tsdf_mesh_integrator.cc
+++ b/global_segment_map/src/meshing/label_tsdf_mesh_integrator.cc
@@ -231,9 +231,13 @@ void MeshLabelIntegrator::updateMeshColor(const Block<LabelVoxel>& label_block,
           label_color_map_.getColor(voxel.label, &(mesh->colors[i]));
         } break;
         case kSemantic: {
-          SemanticLabel semantic_label =
-              semantic_instance_label_fusion_ptr_->getSemanticLabel(
-                  voxel.label);
+          SemanticLabel semantic_label = 0u;
+          InstanceLabel instance_label = getInstanceLabel(voxel.label);
+          if (instance_label != 0u) {
+            semantic_label =
+                semantic_instance_label_fusion_ptr_->getSemanticLabel(
+                    voxel.label);
+          }
           // TODO(margaritaG) : fix this.
           // all_semantic_labels_ptr_->insert(semantic_label);
           semantic_color_map_.getColor(semantic_label, &(mesh->colors[i]));
@@ -268,9 +272,13 @@ void MeshLabelIntegrator::updateMeshColor(const Block<LabelVoxel>& label_block,
               voxel, label_tsdf_config_.max_confidence, &(mesh->colors[i]));
         } break;
         case kSemantic: {
-          SemanticLabel semantic_label =
-              semantic_instance_label_fusion_ptr_->getSemanticLabel(
-                  voxel.label);
+          SemanticLabel semantic_label = 0u;
+          InstanceLabel instance_label = getInstanceLabel(voxel.label);
+          if (instance_label != 0u) {
+            semantic_label =
+                semantic_instance_label_fusion_ptr_->getSemanticLabel(
+                    voxel.label);
+          }
           // TODO(margaritaG) : fix this.
           // all_semantic_labels_ptr_->insert(semantic_label);
           semantic_color_map_.getColor(semantic_label, &(mesh->colors[i]));

--- a/global_segment_map_node/CMakeLists.txt
+++ b/global_segment_map_node/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
-set(WITH_APPROXMVBB OFF)
+set(WITH_APPROXMVBB ON)
 
 if (WITH_APPROXMVBB)
   if(${CMAKE_VERSION} VERSION_LESS "3.8.0")

--- a/global_segment_map_node/include/voxblox_gsm/controller.h
+++ b/global_segment_map_node/include/voxblox_gsm/controller.h
@@ -13,6 +13,7 @@
 #include <global_segment_map/label_voxel.h>
 #include <global_segment_map/meshing/label_tsdf_mesh_integrator.h>
 #include <global_segment_map/utils/visualizer.h>
+#include <gsm_node/GetListSemanticInstances.h>
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <std_srvs/Empty.h>
@@ -48,6 +49,9 @@ class Controller {
   void advertiseExtractInstancesService(
       ros::ServiceServer* extract_instances_srv);
 
+  void advertiseGetListSemanticInstancesService(
+      ros::ServiceServer* get_list_semantic_categories_srv);
+
   bool enable_semantic_instance_segmentation_;
 
   bool publish_scene_mesh_;
@@ -72,6 +76,10 @@ class Controller {
 
   bool extractInstancesCallback(std_srvs::Empty::Request& request,
                                 std_srvs::Empty::Response& response);
+
+  bool getListSemanticInstancesCallback(
+      gsm_node::GetListSemanticInstances::Request& /* request */,
+      gsm_node::GetListSemanticInstances::Response& response);
 
   bool lookupTransform(const std::string& from_frame,
                        const std::string& to_frame, const ros::Time& timestamp,

--- a/global_segment_map_node/include/voxblox_gsm/controller.h
+++ b/global_segment_map_node/include/voxblox_gsm/controller.h
@@ -7,13 +7,11 @@
 #include <vector>
 
 #include <geometry_msgs/Transform.h>
-
 #include <global_segment_map/label_tsdf_integrator.h>
 #include <global_segment_map/label_tsdf_map.h>
 #include <global_segment_map/label_voxel.h>
 #include <global_segment_map/meshing/label_tsdf_mesh_integrator.h>
 #include <global_segment_map/utils/visualizer.h>
-#include <gsm_node/GetListSemanticInstances.h>
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <std_srvs/Empty.h>
@@ -22,6 +20,8 @@
 #include <tf2_ros/transform_broadcaster.h>
 #include <voxblox/io/mesh_ply.h>
 #include <voxblox_ros/conversions.h>
+#include "gsm_node/GetAlignedInstanceBoundingBox.h"
+#include "gsm_node/GetListSemanticInstances.h"
 
 namespace voxblox {
 namespace voxblox_gsm {
@@ -52,6 +52,9 @@ class Controller {
   void advertiseGetListSemanticInstancesService(
       ros::ServiceServer* get_list_semantic_categories_srv);
 
+  void advertiseGetAlignedInstanceBoundingBoxService(
+      ros::ServiceServer* get_instance_bounding_box_srv);
+
   bool enable_semantic_instance_segmentation_;
 
   bool publish_scene_mesh_;
@@ -81,6 +84,10 @@ class Controller {
       gsm_node::GetListSemanticInstances::Request& /* request */,
       gsm_node::GetListSemanticInstances::Response& response);
 
+  bool getAlignedInstanceBoundingBoxCallback(
+      gsm_node::GetAlignedInstanceBoundingBox::Request& request,
+      gsm_node::GetAlignedInstanceBoundingBox::Response& response);
+
   bool lookupTransform(const std::string& from_frame,
                        const std::string& to_frame, const ros::Time& timestamp,
                        Transformation* transform);
@@ -93,6 +100,11 @@ class Controller {
       const pcl::PointCloud<pcl::PointSurfel>::Ptr surfel_cloud,
       Eigen::Vector3f* bbox_translation, Eigen::Quaternionf* bbox_quaternion,
       Eigen::Vector3f* bbox_size);
+
+  void extractInstanceSegments(
+      InstanceLabels instance_labels, bool save_segments_as_ply,
+      std::unordered_map<InstanceLabel, LabelTsdfMap::LayerPair>*
+          instance_label_to_layers);
 
   ros::NodeHandle* node_handle_private_;
 

--- a/global_segment_map_node/include/voxblox_gsm/conversions.h
+++ b/global_segment_map_node/include/voxblox_gsm/conversions.h
@@ -50,6 +50,67 @@ inline void voxelEvaluationDetails2VoxelEvaluationDetailsMsg(
   }
 }
 
+inline void fillAlignedBoundingBoxMsg(
+    Eigen::Vector3f bbox_translation, Eigen::Quaternionf bbox_quaternion,
+    Eigen::Vector3f bbox_size, modelify_msgs::BoundingBox* bounding_box_msg) {
+  CHECK_NOTNULL(bounding_box_msg);
+  bounding_box_msg->pose.position.x = bbox_translation(0);
+  bounding_box_msg->pose.position.y = bbox_translation(1);
+  bounding_box_msg->pose.position.z = bbox_translation(2);
+  bounding_box_msg->pose.orientation.x = bbox_quaternion.x();
+  bounding_box_msg->pose.orientation.y = bbox_quaternion.y();
+  bounding_box_msg->pose.orientation.z = bbox_quaternion.z();
+  bounding_box_msg->pose.orientation.w = bbox_quaternion.w();
+  bounding_box_msg->dimensions.x = bbox_size(0);
+  bounding_box_msg->dimensions.y = bbox_size(1);
+  bounding_box_msg->dimensions.z = bbox_size(2);
+}
+
+inline void fillBoundingBoxMarkerMsg(std::string world_frame, uint32_t id,
+                                     Eigen::Vector3f bbox_translation,
+                                     Eigen::Quaternionf bbox_quaternion,
+                                     Eigen::Vector3f bbox_size,
+                                     visualization_msgs::Marker* bbox_marker) {
+  CHECK_NOTNULL(bbox_marker);
+  bbox_marker->header.frame_id = world_frame;
+  bbox_marker->header.stamp = ros::Time();
+  bbox_marker->id = id;
+  bbox_marker->type = visualization_msgs::Marker::CUBE;
+  bbox_marker->action = visualization_msgs::Marker::ADD;
+  bbox_marker->pose.position.x = bbox_translation(0);
+  bbox_marker->pose.position.y = bbox_translation(1);
+  bbox_marker->pose.position.z = bbox_translation(2);
+  bbox_marker->pose.orientation.x = bbox_quaternion.x();
+  bbox_marker->pose.orientation.y = bbox_quaternion.y();
+  bbox_marker->pose.orientation.z = bbox_quaternion.z();
+  bbox_marker->pose.orientation.w = bbox_quaternion.w();
+  bbox_marker->scale.x = bbox_size(0);
+  bbox_marker->scale.y = bbox_size(1);
+  bbox_marker->scale.z = bbox_size(2);
+  bbox_marker->color.a = 0.3;
+  bbox_marker->color.r = 0.0;
+  bbox_marker->color.g = 1.0;
+  bbox_marker->color.b = 0.0;
+  bbox_marker->lifetime = ros::Duration();
+}
+
+inline void fillBoundingBoxTfMsg(std::string world_frame,
+                                 std::string child_frame,
+                                 Eigen::Vector3f bbox_translation,
+                                 Eigen::Quaternionf bbox_quaternion,
+                                 geometry_msgs::TransformStamped* bbox_tf) {
+  bbox_tf->header.stamp = ros::Time();
+  bbox_tf->header.frame_id = world_frame;
+  bbox_tf->child_frame_id = child_frame;
+  bbox_tf->transform.translation.x = bbox_translation(0);
+  bbox_tf->transform.translation.y = bbox_translation(1);
+  bbox_tf->transform.translation.z = bbox_translation(2);
+  bbox_tf->transform.rotation.x = bbox_quaternion.x();
+  bbox_tf->transform.rotation.y = bbox_quaternion.y();
+  bbox_tf->transform.rotation.z = bbox_quaternion.z();
+  bbox_tf->transform.rotation.w = bbox_quaternion.w();
+}
+
 inline void convertVoxelGridToPointCloud(
     const voxblox::Layer<voxblox::TsdfVoxel>& tsdf_voxels,
     const MeshIntegratorConfig& mesh_config,
@@ -94,7 +155,7 @@ inline void convertVoxelGridToPointCloud(
   surfel_cloud->height = 1u;
 }
 
-bool convertLabelTsdfLayersToMesh(
+inline bool convertLabelTsdfLayersToMesh(
     const Layer<TsdfVoxel>& tsdf_layer, const Layer<LabelVoxel>& label_layer,
     voxblox::Mesh* mesh, const bool connected_mesh = true,
     const FloatingPoint vertex_proximity_threshold = 1e-10) {

--- a/global_segment_map_node/package.xml
+++ b/global_segment_map_node/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gsm_node</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Voxblox++ ROS interface</description>
 
   <author email="margarita.grinvald@mavt.ethz.ch">Margarita Grinvald</author>
@@ -20,17 +20,19 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
 
   <depend>gflags_catkin</depend>
+  <depend>global_segment_map</depend>
+  <depend>global_feature_map</depend>
   <depend>glog_catkin</depend>
+  <depend>message_generation</depend>
+  <depend>message_runtime</depend>
   <depend>minkindr_conversions</depend>
   <depend>modelify_msgs</depend>
+  <depend>opencv3_catkin</depend>
   <depend>pcl_catkin</depend>
   <depend>pcl_conversions</depend>
   <depend>roscpp</depend>
+  <depend>std_msgs</depend>
   <depend>voxblox</depend>
-  <depend>global_segment_map</depend>
-  <depend>global_feature_map</depend>
   <depend>voxblox_msgs</depend>
   <depend>voxblox_ros</depend>
-  <depend>opencv3_catkin</depend>
-
 </package>

--- a/global_segment_map_node/package.xml
+++ b/global_segment_map_node/package.xml
@@ -31,6 +31,7 @@
   <depend>pcl_catkin</depend>
   <depend>pcl_conversions</depend>
   <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>voxblox</depend>
   <depend>voxblox_msgs</depend>

--- a/global_segment_map_node/src/controller.cpp
+++ b/global_segment_map_node/src/controller.cpp
@@ -656,17 +656,16 @@ bool Controller::getAlignedInstanceBoundingBoxCallback(
     fillAlignedBoundingBoxMsg(bbox_translation, bbox_quaternion, bbox_size,
                               &response.bbox);
 
-    if (compute_and_publish_bbox_) {
-      visualization_msgs::Marker bbox_marker;
-      fillBoundingBoxMarkerMsg(world_frame_, instance_label, bbox_translation,
-                               bbox_quaternion, bbox_size, &bbox_marker);
-      bbox_pub_->publish(bbox_marker);
+    // Visualize bounding box in RViz.
+    visualization_msgs::Marker bbox_marker;
+    fillBoundingBoxMarkerMsg(world_frame_, instance_label, bbox_translation,
+                             bbox_quaternion, bbox_size, &bbox_marker);
+    bbox_pub_->publish(bbox_marker);
 
-      geometry_msgs::TransformStamped bbox_tf;
-      fillBoundingBoxTfMsg(world_frame_, std::to_string(instance_label),
-                           bbox_translation, bbox_quaternion, &bbox_tf);
-      tf_broadcaster_.sendTransform(bbox_tf);
-    }
+    geometry_msgs::TransformStamped bbox_tf;
+    fillBoundingBoxTfMsg(world_frame_, std::to_string(instance_label),
+                         bbox_translation, bbox_quaternion, &bbox_tf);
+    tf_broadcaster_.sendTransform(bbox_tf);
   }
 
   return true;

--- a/global_segment_map_node/src/controller.cpp
+++ b/global_segment_map_node/src/controller.cpp
@@ -367,6 +367,14 @@ void Controller::advertiseExtractInstancesService(
       "extract_instances", &Controller::extractInstancesCallback, this);
 }
 
+void Controller::advertiseGetListSemanticInstancesService(
+    ros::ServiceServer* get_list_semantic_instances_srv) {
+  CHECK_NOTNULL(get_list_semantic_instances_srv);
+  *get_list_semantic_instances_srv = node_handle_private_->advertiseService(
+      "get_list_semantic_instances",
+      &Controller::getListSemanticInstancesCallback, this);
+}
+
 void Controller::processSegment(
     const sensor_msgs::PointCloud2::Ptr& segment_point_cloud_msg) {
   // Look up transform from camera frame to world frame.
@@ -589,6 +597,21 @@ bool Controller::saveSegmentsAsMeshCallback(
   }
 
   return overall_success;
+}
+
+bool Controller::getListSemanticInstancesCallback(
+    gsm_node::GetListSemanticInstances::Request& /* request */,
+    gsm_node::GetListSemanticInstances::Response& response) {
+  SemanticLabels semantic_labels;
+
+  // Get the semantic class of each recognized instance in the map.
+  semantic_labels = map_->getSemanticInstanceList();
+
+  // Map class id to human-readable label.
+  for (const SemanticLabel semantic_label : semantic_labels) {
+    response.semantic_categories.push_back(classes[(unsigned)semantic_label]);
+  }
+  return true;
 }
 
 bool Controller::extractInstancesCallback(std_srvs::Empty::Request& request,

--- a/global_segment_map_node/src/iodb_controller.cpp
+++ b/global_segment_map_node/src/iodb_controller.cpp
@@ -3,15 +3,12 @@
 
 #include "voxblox_gsm/iodb_controller.h"
 
+#include <global_segment_map/meshing/label_tsdf_mesh_integrator.h>
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
-
-#include <global_segment_map/meshing/label_tsdf_mesh_integrator.h>
-
 #include <voxblox/integrator/merge_integration.h>
 #include <voxblox/utils/layer_utils.h>
 #include <voxblox_ros/mesh_vis.h>
-
 #include "voxblox_gsm/conversions.h"
 #include "voxblox_gsm/feature_ros_tools.h"
 

--- a/global_segment_map_node/src/node.cpp
+++ b/global_segment_map_node/src/node.cpp
@@ -29,6 +29,7 @@ int main(int argc, char** argv) {
     controller->advertiseSceneMeshTopic();
   }
 
+  ros::ServiceServer get_instance_bounding_box_srv;
   if (controller->compute_and_publish_bbox_) {
     controller->advertiseBboxTopic();
   }
@@ -41,14 +42,16 @@ int main(int argc, char** argv) {
 
   ros::ServiceServer extract_instances_srv;
   ros::ServiceServer get_list_semantic_instances_srv;
-  ros::ServiceServer get_instance_bounding_box_srv;
 
   if (controller->enable_semantic_instance_segmentation_) {
     controller->advertiseExtractInstancesService(&extract_instances_srv);
     controller->advertiseGetListSemanticInstancesService(
         &get_list_semantic_instances_srv);
-    controller->advertiseGetAlignedInstanceBoundingBoxService(
-        &get_instance_bounding_box_srv);
+
+    if (controller->compute_and_publish_bbox_) {
+      controller->advertiseGetAlignedInstanceBoundingBoxService(
+          &get_instance_bounding_box_srv);
+    }
   }
 
   // Spinner that uses a number of threads equal to the number of cores.

--- a/global_segment_map_node/src/node.cpp
+++ b/global_segment_map_node/src/node.cpp
@@ -41,10 +41,14 @@ int main(int argc, char** argv) {
 
   ros::ServiceServer extract_instances_srv;
   ros::ServiceServer get_list_semantic_instances_srv;
+  ros::ServiceServer get_instance_bounding_box_srv;
+
   if (controller->enable_semantic_instance_segmentation_) {
     controller->advertiseExtractInstancesService(&extract_instances_srv);
     controller->advertiseGetListSemanticInstancesService(
         &get_list_semantic_instances_srv);
+    controller->advertiseGetAlignedInstanceBoundingBoxService(
+        &get_instance_bounding_box_srv);
   }
 
   // Spinner that uses a number of threads equal to the number of cores.

--- a/global_segment_map_node/src/node.cpp
+++ b/global_segment_map_node/src/node.cpp
@@ -40,8 +40,11 @@ int main(int argc, char** argv) {
   controller->advertiseSaveSegmentsAsMeshService(&save_segments_as_mesh_srv);
 
   ros::ServiceServer extract_instances_srv;
+  ros::ServiceServer get_list_semantic_instances_srv;
   if (controller->enable_semantic_instance_segmentation_) {
     controller->advertiseExtractInstancesService(&extract_instances_srv);
+    controller->advertiseGetListSemanticInstancesService(
+        &get_list_semantic_instances_srv);
   }
 
   // Spinner that uses a number of threads equal to the number of cores.

--- a/global_segment_map_node/srv/GetAlignedInstanceBoundingBox.srv
+++ b/global_segment_map_node/srv/GetAlignedInstanceBoundingBox.srv
@@ -1,0 +1,3 @@
+uint16 instance_id
+---
+modelify_msgs/BoundingBox bbox

--- a/global_segment_map_node/srv/GetListSemanticInstances.srv
+++ b/global_segment_map_node/srv/GetListSemanticInstances.srv
@@ -1,2 +1,3 @@
 ---
+uint16[] instance_ids
 string[] semantic_categories

--- a/global_segment_map_node/srv/GetListSemanticInstances.srv
+++ b/global_segment_map_node/srv/GetListSemanticInstances.srv
@@ -1,0 +1,2 @@
+---
+string[] semantic_categories


### PR DESCRIPTION
Added two services with corresponding back-end logic:
- One to query the list of semantic instances in the map (return the list of instance_ids and their semantic category)
- And one to query, given an instance_id, the aligned bounding box of that instance.

Also: 
- Refactored order of includes in a couple of files
- Fixed semantic meshing which was ignoring a possible kFramesCountThresholdFactor
- Refactored the extract_instances service to re-use code when retrieving the layer of a single instance.
