### PR TITLE
Visualizer and debug parameters

### DIFF
--- a/global_segment_map/include/global_segment_map/utils/visualizer.h
+++ b/global_segment_map/include/global_segment_map/utils/visualizer.h
@@ -11,7 +11,9 @@ namespace voxblox {
 class Visualizer {
  public:
   Visualizer(const std::vector<std::shared_ptr<MeshLayer>>& mesh_layers,
-             bool* mesh_layer_updated, std::mutex* mesh_layer_mutex_ptr);
+             bool* mesh_layer_updated, std::mutex* mesh_layer_mutex_ptr,
+             std::vector<double> camera_distances,
+             std::vector<double> clip_distances, bool save_visualizer_frames);
 
   void visualizeMesh();
 
@@ -21,6 +23,11 @@ class Visualizer {
   bool* mesh_layer_updated_;
 
   size_t frame_count_;
+
+  std::vector<double> camera_position_;
+  std::vector<double> clip_distances_;
+
+  bool save_visualizer_frames_;
 };
 }  // namespace voxblox
 

--- a/global_segment_map_node/cfg/asl_office_floor.yaml
+++ b/global_segment_map_node/cfg/asl_office_floor.yaml
@@ -13,3 +13,11 @@ meshing:
   visualize: true
   update_mesh_every_n_sec: 2.0
   publish_scene_mesh: false
+  visualizer_parameters:
+    camera_position: [ -9.26672, -7.73843, 22.3946,
+                      -12.9445,  -8.20767, -5.76437,
+                       -0.395892, 0.917575, 0.0364161]
+    clip_distances: [16.4938, 31.2009]
+
+debug:
+  verbose_log: true

--- a/global_segment_map_node/cfg/default.yaml
+++ b/global_segment_map_node/cfg/default.yaml
@@ -29,8 +29,16 @@ meshing:
   publish_scene_mesh: true
   mesh_filename: "vpp_mesh.ply"
   compute_and_publish_bbox: false
-  min_weight: 3
+  visualizer_parameters:
+    camera_position: [-0.73071,  1.35896,   6.98444,  # Position - x y z
+                       0.204536, 0.470912,  0.381721, # Focal point - x y z
+                      -0.945969, 0.275475, -0.171043] # View up - x y z
+    clip_distances: [5.87024, 8.29843]
 
 icp:
   enable_icp: false
   keep_track_of_icp_correction: true
+
+debug:
+  verbose_log: false
+  save_visualizer_frames: false

--- a/global_segment_map_node/cfg/scenenn.yaml
+++ b/global_segment_map_node/cfg/scenenn.yaml
@@ -13,3 +13,11 @@ meshing:
   visualize: true
   update_mesh_every_n_sec: 2.0
   publish_scene_mesh: false
+  visualizer_parameters:
+    camera_position: [-1.41162,    6.28602,   -0.300336,
+                      -1.49346,    0.117437,   0.0843885,
+                       0.0165199, -0.0624571, -0.997911]
+    clip_distances: [1.79126, 8.86051]
+
+debug:
+  verbose_log: true

--- a/global_segment_map_node/launch/asl_office_floor_dataset.launch
+++ b/global_segment_map_node/launch/asl_office_floor_dataset.launch
@@ -3,6 +3,8 @@
   <arg name="bag_file" default="/path/to/data.bag"/>
   <arg name="visualize" default="true" />
 
+  <!-- Download the dataset here: https://projects.asl.ethz.ch/datasets/doku.php?id=voxblox-plusplus -->
+
   <include file="$(find gsm_node)/launch/vpp_pipeline.launch">
     <arg name="scene_name" value="asl_office_floor" />
     <arg name="sensor_name" value="primesense" />

--- a/global_segment_map_node/launch/gsm_node.launch
+++ b/global_segment_map_node/launch/gsm_node.launch
@@ -6,6 +6,5 @@
     <rosparam command="load" file="$(find gsm_node)/cfg/default.yaml" />
     <rosparam command="load" file="$(find gsm_node)/cfg/$(arg scene_name).yaml" />
     <param name="meshing/visualize" value="$(arg visualize)" />
-    <param name="meshing/update_mesh_every_n_sec" value="0.0" unless="$(arg visualize)" />
   </node>
 </launch>

--- a/global_segment_map_node/launch/scenenn_dataset.launch
+++ b/global_segment_map_node/launch/scenenn_dataset.launch
@@ -3,6 +3,8 @@
   <arg name="bag_file" default="/path/to/data.bag"/>
   <arg name="visualize" default="true" />
 
+  <!-- Download the dataset here: https://projects.asl.ethz.ch/datasets/doku.php?id=voxblox-plusplus -->
+
   <include file="$(find gsm_node)/launch/vpp_pipeline.launch">
     <arg name="scene_name" value="scenenn" />
     <arg name="sensor_name" value="primesense" />

--- a/global_segment_map_node/package.xml
+++ b/global_segment_map_node/package.xml
@@ -22,14 +22,9 @@
   <depend>gflags_catkin</depend>
   <depend>global_segment_map</depend>
   <depend>glog_catkin</depend>
-  <depend>message_generation</depend>
-  <depend>message_runtime</depend>
   <depend>minkindr_conversions</depend>
-  <depend>modelify_msgs</depend>
-  <depend>opencv3_catkin</depend>
   <depend>pcl_catkin</depend>
   <depend>pcl_conversions</depend>
-  <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>voxblox</depend>

--- a/global_segment_map_node/src/node.cpp
+++ b/global_segment_map_node/src/node.cpp
@@ -13,12 +13,15 @@ int main(int argc, char** argv) {
   google::ParseCommandLineFlags(&argc, &argv, false);
   google::InstallFailureSignalHandler();
 
-  FLAGS_stderrthreshold = 1;
   ros::NodeHandle node_handle;
   ros::NodeHandle node_handle_private("~");
 
   voxblox::voxblox_gsm::Controller* controller;
-  LOG(INFO) << "Starting Voxblox++ node.";
+
+  std::cout << endl
+            << "Voxblox++ Copyright (C) 2016-2020 ASL, ETH Zurich." << endl
+            << endl;
+
   controller = new voxblox::voxblox_gsm::Controller(&node_handle_private);
 
   ros::ServiceServer reset_map_srv;

--- a/voxblox-plusplus_https.rosinstall
+++ b/voxblox-plusplus_https.rosinstall
@@ -35,9 +35,6 @@
     local-name: numpy_eigen
     uri: https://github.com/ethz-asl/numpy_eigen.git
 - git:
-    local-name: modelify_msgs
-    uri: https://github.com/ethz-asl/modelify_msgs.git
-- git:
     local-name: opencv3_catkin
     uri: https://github.com/ethz-asl/opencv3_catkin.git
 - git:
@@ -47,6 +44,3 @@
 - git:
     local-name: vpp_msgs
     uri: https://github.com/ethz-asl/vpp_msgs.git
-- git:
-    local-name: yaml_cpp_catkin
-    uri: https://github.com/ethz-asl/yaml_cpp_catkin.git

--- a/voxblox-plusplus_ssh.rosinstall
+++ b/voxblox-plusplus_ssh.rosinstall
@@ -35,9 +35,6 @@
     local-name: numpy_eigen
     uri: git@github.com:ethz-asl/numpy_eigen.git
 - git:
-    local-name: modelify_msgs
-    uri: git@github.com:ethz-asl/modelify_msgs.git
-- git:
     local-name: opencv3_catkin
     uri: git@github.com:ethz-asl/opencv3_catkin.git
 - git:
@@ -47,6 +44,3 @@
 - git:
     local-name: vpp_msgs
     uri: git@github.com:ethz-asl/vpp_msgs.git
-- git:
-    local-name: yaml_cpp_catkin
-    uri: git@github.com:ethz-asl/yaml_cpp_catkin.git


### PR DESCRIPTION
- Add a default value and parametrize the visualizer settings such as camera position/focal point and clipping planes so that specific scenes could have set a custom viewpoint for the entire session.
- Changed all ROS logging to GLOG to allow for changing the std output verbosity at runtime.
- Add parameters for debug purposes (e.g. enable/disable verbose logging, enable/disable storing to disk of the visualizer frames).