### PR TITLE
Online mapping with ORBSLAM2

### DIFF
--- a/global_segment_map_node/cfg/default.yaml
+++ b/global_segment_map_node/cfg/default.yaml
@@ -41,4 +41,5 @@ icp:
 
 debug:
   verbose_log: false
+  multiple_visualizers: false
   save_visualizer_frames: false

--- a/global_segment_map_node/cfg/orb_slam2.yaml
+++ b/global_segment_map_node/cfg/orb_slam2.yaml
@@ -1,10 +1,10 @@
 world_frame_id: "map"
 
 voxblox:
-  voxel_size: 0.02
+  voxel_size: 0.015
   truncation_distance_factor: 5.0
   voxel_carving_enabled: false
-  max_ray_length_m: 2
+  max_ray_length_m: 3
 
 semantic_instance_segmentation:
   enable_semantic_instance_segmentation: true
@@ -13,6 +13,11 @@ meshing:
   visualize: true
   publish_scene_mesh: false
   update_mesh_every_n_sec: 2.0
+  visualizer_parameters:
+    camera_position: [-1.91571,  -0.148907, 1.38851,   # Position - x y z
+                       0.335035, -1.0907,  -0.0125681, # Focal point - x y z
+                       0.480502, -0.139695, 0.865796]  # View up - x y z
+    clip_distances: [ 0.00685696, 6.85696]
 
 debug:
   verbose_log: false

--- a/global_segment_map_node/cfg/orb_slam2.yaml
+++ b/global_segment_map_node/cfg/orb_slam2.yaml
@@ -1,0 +1,18 @@
+world_frame_id: "map"
+
+voxblox:
+  voxel_size: 0.02
+  truncation_distance_factor: 5.0
+  voxel_carving_enabled: false
+  max_ray_length_m: 2
+
+semantic_instance_segmentation:
+  enable_semantic_instance_segmentation: true
+
+meshing:
+  visualize: true
+  publish_scene_mesh: false
+  update_mesh_every_n_sec: 2.0
+
+debug:
+  verbose_log: false

--- a/global_segment_map_node/include/global_segment_map_node/controller.h
+++ b/global_segment_map_node/include/global_segment_map_node/controller.h
@@ -185,6 +185,7 @@ class Controller {
   std::mutex mesh_layer_mutex_;
   bool mesh_layer_updated_;
   bool need_full_remesh_;
+  bool multiple_visualizers_;
 };
 
 }  // namespace voxblox_gsm

--- a/global_segment_map_node/launch/orb_slam2.launch
+++ b/global_segment_map_node/launch/orb_slam2.launch
@@ -1,0 +1,12 @@
+<launch>
+  <arg name="visualize" default="true" />
+
+  <include file="$(find gsm_node)/launch/vpp_pipeline.launch">
+    <arg name="scene_name" value="orb_slam2" />
+    <arg name="sensor_name" value="primesense" />
+    <arg name="visualize" value="$(arg visualize)" />
+  </include>
+
+  <include file="$(find orb_slam2_ros)/ros/launch/orb_slam2_primesense_rgbd.launch">
+  </include>
+</launch>


### PR DESCRIPTION
- By default only visualize one 3D mesh (the geometric + (if available) semantic one). Added a parameter to optionally also visualize the geometric-only map, the semantic-only map, and the instance-only map.
- Added a launch and config file for relying on [orb_slam_2_ros](https://github.com/margaritaG/orb_slam_2_ros) for RGB-D based camera pose tracking.