### PR TITLE
Advance pcl to 1.10

### DIFF
--- a/voxblox-plusplus_https.rosinstall
+++ b/voxblox-plusplus_https.rosinstall
@@ -40,7 +40,7 @@
 - git:
     local-name: pcl_catkin
     uri: https://github.com/ethz-asl/pcl_catkin.git
-    version: fix/pcl-1.10
+    version: fix/advance_perception_pcl
 - git:
     local-name: vpp_msgs
     uri: https://github.com/ethz-asl/vpp_msgs.git

--- a/voxblox-plusplus_https.rosinstall
+++ b/voxblox-plusplus_https.rosinstall
@@ -40,7 +40,7 @@
 - git:
     local-name: pcl_catkin
     uri: https://github.com/ethz-asl/pcl_catkin.git
-    version: fix/pcl-1.9.1
+    version: fix/pcl-1.10
 - git:
     local-name: vpp_msgs
     uri: https://github.com/ethz-asl/vpp_msgs.git

--- a/voxblox-plusplus_ssh.rosinstall
+++ b/voxblox-plusplus_ssh.rosinstall
@@ -40,7 +40,7 @@
 - git:
     local-name: pcl_catkin
     uri: git@github.com:ethz-asl/pcl_catkin.git
-    version: fix/pcl-1.10
+    version: fix/advance_perception_pcl
 - git:
     local-name: vpp_msgs
     uri: git@github.com:ethz-asl/vpp_msgs.git

--- a/voxblox-plusplus_ssh.rosinstall
+++ b/voxblox-plusplus_ssh.rosinstall
@@ -40,7 +40,7 @@
 - git:
     local-name: pcl_catkin
     uri: git@github.com:ethz-asl/pcl_catkin.git
-    version: fix/pcl-1.9.1
+    version: fix/pcl-1.10
 - git:
     local-name: vpp_msgs
     uri: git@github.com:ethz-asl/vpp_msgs.git


### PR DESCRIPTION
Advancing PCL version to 1.10 via pcl_catkin to check everything compiles.

Should solve https://github.com/ethz-asl/voxblox-plusplus/issues/66.