### PR TITLE
Publish map service

### DIFF
--- a/global_segment_map/include/global_segment_map/common.h
+++ b/global_segment_map/include/global_segment_map/common.h
@@ -57,20 +57,44 @@ struct PointSurfelSemanticInstance {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 } EIGEN_ALIGN16;
 
+// Map pointcloud type.
+struct PointTSDFLabel {
+  PCL_ADD_POINT4D;
+
+  // TSDF fields.
+  float distance;
+  float weight;
+
+  // Semantic segmentation fields.
+  Label segment_label;
+  SemanticLabel semantic_class;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+} EIGEN_ALIGN16;
+
 typedef pcl::PointXYZRGB PointType;
 typedef PointSurfelLabel PointLabelType;
 typedef PointSurfelSemanticInstance PointSemanticInstanceType;
+typedef PointTSDFLabel PointMapType;
 
 }  // namespace voxblox
 
-POINT_CLOUD_REGISTER_POINT_STRUCT(voxblox::PointSurfelLabel,
-                                  (float, x, x)(float, y, y)(float, z, z)(
-                                      float, rgb, rgb)(uint32_t, label, label))
+POINT_CLOUD_REGISTER_POINT_STRUCT(
+    voxblox::PointSurfelLabel,
+    (float, x, x)(float, y, y)(float, z, z)(float, rgb, rgb)(std::uint32_t,
+                                                             label, label))
 
 POINT_CLOUD_REGISTER_POINT_STRUCT(
     voxblox::PointSemanticInstanceType,
     (float, x, x)(float, y, y)(float, z, z)(float, rgb, rgb)(
-        uint8_t, instance_label,
+        std::uint8_t, instance_label,
         instance_label)(voxblox::SemanticLabel, semantic_label, semantic_label))
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(
+    voxblox::PointTSDFLabel,
+    (float, x, x)(float, y, y)(float, z, z)(float, distance, distance)(
+        float, weight, weight)(voxblox::Label, segment_label,
+                               segment_label)(voxblox::SemanticLabel,
+                                              semantic_class, semantic_class))
 
 #endif  // GLOBAL_SEGMENT_MAP_COMMON_H_

--- a/global_segment_map/include/global_segment_map/utils/layer_utils.h
+++ b/global_segment_map/include/global_segment_map/utils/layer_utils.h
@@ -3,7 +3,7 @@
 
 #include <voxblox/utils/layer_utils.h>
 
-#include "global_segment_map/lable_voxel.h"
+#include "global_segment_map/label_voxel.h"
 
 namespace voxblox {
 namespace utils {

--- a/global_segment_map/include/global_segment_map/utils/map_utils.h
+++ b/global_segment_map/include/global_segment_map/utils/map_utils.h
@@ -1,0 +1,77 @@
+#ifndef GLOBAL_SEGMENT_MAP_UTILS_MAP_UTILS_H_
+#define GLOBAL_SEGMENT_MAP_UTILS_MAP_UTILS_H_
+
+#include <global_segment_map/common.h>
+#include <global_segment_map/label_tsdf_map.h>
+#include <global_segment_map/semantic_instance_label_fusion.h>
+
+namespace voxblox {
+
+inline void createPointcloudFromMap(const LabelTsdfMap& map,
+                                    pcl::PointCloud<PointMapType>* pointcloud) {
+  CHECK_NOTNULL(pointcloud);
+  pointcloud->clear();
+
+  const Layer<TsdfVoxel>& tsdf_layer = map.getTsdfLayer();
+  const Layer<LabelVoxel>& label_layer = map.getLabelLayer();
+
+  const SemanticInstanceLabelFusion semantic_instance_label_fusion =
+      map.getSemanticInstanceLabelFusion();
+
+  BlockIndexList blocks;
+  tsdf_layer.getAllAllocatedBlocks(&blocks);
+
+  // Cache layer settings.
+  size_t vps = tsdf_layer.voxels_per_side();
+  size_t num_voxels_per_block = vps * vps * vps;
+
+  // Temp variables.
+  double intensity = 0.0;
+  // Iterate over all blocks.
+  for (const BlockIndex& index : blocks) {
+    const Block<TsdfVoxel>& tsdf_block = tsdf_layer.getBlockByIndex(index);
+    const Block<LabelVoxel>& label_block = label_layer.getBlockByIndex(index);
+
+    // Iterate over all voxels in said blocks.
+    for (size_t linear_index = 0; linear_index < num_voxels_per_block;
+         ++linear_index) {
+      Point coord = tsdf_block.computeCoordinatesFromLinearIndex(linear_index);
+
+      TsdfVoxel tsdf_voxel = tsdf_block.getVoxelByLinearIndex(linear_index);
+      LabelVoxel label_voxel = label_block.getVoxelByLinearIndex(linear_index);
+
+      constexpr float kMinWeight = 0.0f;
+      constexpr float kFramesCountThresholdFactor = 0.1f;
+
+      if (tsdf_voxel.weight > kMinWeight) {
+        Label segment_label = label_voxel.label;
+        SemanticLabel semantic_class = BackgroundLabel;
+        InstanceLabel instance_id =
+            semantic_instance_label_fusion.getInstanceLabel(
+                segment_label, kFramesCountThresholdFactor);
+
+        if (instance_id) {
+          semantic_class = semantic_instance_label_fusion.getSemanticLabel(
+              label_voxel.label);
+        }
+
+        PointMapType point;
+
+        point.x = coord.x();
+        point.y = coord.y();
+        point.z = coord.z();
+
+        point.distance = tsdf_voxel.distance;
+        point.weight = tsdf_voxel.weight;
+
+        point.segment_label = segment_label;
+        point.semantic_class = semantic_class;
+        pointcloud->push_back(point);
+      }
+    }
+  }
+}
+
+}  // namespace voxblox
+
+#endif  // GLOBAL_SEGMENT_MAP_UTILS_MAP_UTILS_H_

--- a/global_segment_map_node/cfg/default.yaml
+++ b/global_segment_map_node/cfg/default.yaml
@@ -23,12 +23,15 @@ semantic_instance_segmentation:
   enable_semantic_instance_segmentation: false
   class_tsdk: "coco80"
 
+publishers:
+  publish_scene_map: true
+  publish_scene_mesh: true
+  publish_object_bbox: false
+
 meshing:
   visualize: false
   update_mesh_every_n_sec: 0.0
-  publish_scene_mesh: true
   mesh_filename: "vpp_mesh.ply"
-  compute_and_publish_bbox: false
   visualizer_parameters:
     camera_position: [-0.73071,  1.35896,   6.98444,  # Position - x y z
                        0.204536, 0.470912,  0.381721, # Focal point - x y z

--- a/global_segment_map_node/include/global_segment_map_node/controller.h
+++ b/global_segment_map_node/include/global_segment_map_node/controller.h
@@ -22,6 +22,7 @@
 #include <voxblox_ros/conversions.h>
 #include <vpp_msgs/GetAlignedInstanceBoundingBox.h>
 #include <vpp_msgs/GetListSemanticInstances.h>
+#include <vpp_msgs/GetMap.h>
 #include <vpp_msgs/GetScenePointcloud.h>
 
 namespace voxblox {
@@ -38,6 +39,8 @@ class Controller {
   void subscribeSegmentPointCloudTopic(
       ros::Subscriber* segment_point_cloud_sub);
 
+  void advertiseMapTopic();
+
   void advertiseSceneMeshTopic();
 
   void advertiseSceneCloudTopic();
@@ -48,6 +51,8 @@ class Controller {
 
   void advertiseToggleIntegrationService(
       ros::ServiceServer* toggle_integration_srv);
+
+  void advertiseGetMapService(ros::ServiceServer* get_map_srv);
 
   void advertiseGenerateMeshService(ros::ServiceServer* generate_mesh_srv);
 
@@ -68,8 +73,9 @@ class Controller {
 
   bool enable_semantic_instance_segmentation_;
 
+  bool publish_scene_map_;
   bool publish_scene_mesh_;
-  bool compute_and_publish_bbox_;
+  bool publish_object_bbox_;
 
   bool use_label_propagation_;
 
@@ -87,6 +93,9 @@ class Controller {
 
   virtual void segmentPointCloudCallback(
       const sensor_msgs::PointCloud2::Ptr& segment_point_cloud_msg);
+
+  bool getMapCallback(vpp_msgs::GetMap::Request& /* request */,
+                      vpp_msgs::GetMap::Response& response);
 
   bool generateMeshCallback(std_srvs::Empty::Request& request,
                             std_srvs::Empty::Response& response);
@@ -152,8 +161,7 @@ class Controller {
   MeshIntegratorConfig mesh_config_;
   MeshLabelIntegrator::LabelTsdfConfig label_tsdf_mesh_config_;
   ros::Timer update_mesh_timer_;
-  ros::Publisher* scene_mesh_pub_;
-  ros::Publisher* scene_cloud_pub_;
+
   MeshLabelIntegrator::ColorScheme mesh_color_scheme_;
   std::string mesh_filename_;
 
@@ -177,6 +185,10 @@ class Controller {
   std::map<Label, std::map<Segment*, size_t>> segment_label_candidates;
   std::map<Segment*, std::vector<Label>> segment_merge_candidates_;
 
+  // Publishers.
+  ros::Publisher* map_cloud_pub_;
+  ros::Publisher* scene_mesh_pub_;
+  ros::Publisher* scene_cloud_pub_;
   ros::Publisher* bbox_pub_;
 
   std::thread viz_thread_;

--- a/global_segment_map_node/src/controller.cpp
+++ b/global_segment_map_node/src/controller.cpp
@@ -680,7 +680,6 @@ bool Controller::getMapCallback(vpp_msgs::GetMap::Request& /* request */,
   map_pointcloud.header.frame_id = world_frame_;
   pcl::toROSMsg(map_pointcloud, response.map_cloud);
 
-  response.voxels_per_side = map_config_.voxels_per_side;
   response.voxel_size = map_config_.voxel_size;
 
   if (publish_scene_map_) {

--- a/global_segment_map_node/src/controller.cpp
+++ b/global_segment_map_node/src/controller.cpp
@@ -19,6 +19,7 @@
 #include <geometry_msgs/TransformStamped.h>
 #include <global_segment_map/label_voxel.h>
 #include <global_segment_map/utils/file_utils.h>
+#include <global_segment_map/utils/map_utils.h>
 #include <glog/logging.h>
 #include <minkindr_conversions/kindr_tf.h>
 #include <visualization_msgs/Marker.h>
@@ -127,12 +128,13 @@ Controller::Controller(ros::NodeHandle* node_handle_private)
       tf_listener_(ros::Duration(500)),
       world_frame_("world"),
       integration_on_(true),
+      publish_scene_map_(false),
       publish_scene_mesh_(false),
       received_first_message_(false),
       mesh_layer_updated_(false),
       need_full_remesh_(false),
       enable_semantic_instance_segmentation_(true),
-      compute_and_publish_bbox_(false),
+      publish_object_bbox_(false),
       use_label_propagation_(true) {
   CHECK_NOTNULL(node_handle_private_);
 
@@ -292,22 +294,15 @@ Controller::Controller(ros::NodeHandle* node_handle_private)
     viz_thread_ = std::thread(&Visualizer::visualizeMesh, visualizer_);
   }
 
-  node_handle_private_->param<bool>("meshing/publish_scene_mesh",
+  node_handle_private_->param<bool>("publishers/publish_scene_map",
+                                    publish_scene_map_, publish_scene_map_);
+  node_handle_private_->param<bool>("publishers/publish_scene_mesh",
                                     publish_scene_mesh_, publish_scene_mesh_);
-  node_handle_private_->param<bool>("meshing/compute_and_publish_bbox",
-                                    compute_and_publish_bbox_,
-                                    compute_and_publish_bbox_);
+  node_handle_private_->param<bool>("publishers/publish_object_bbox",
+                                    publish_object_bbox_, publish_object_bbox_);
 
   node_handle_private_->param<bool>(
       "use_label_propagation", use_label_propagation_, use_label_propagation_);
-
-#ifndef APPROXMVBB_AVAILABLE
-  if (compute_and_publish_bbox_) {
-    LOG(WARNING) << "ApproxMVBB is not available and therefore "
-                    "bounding box functionality is disabled.";
-  }
-  compute_and_publish_bbox_ = false;
-#endif
 
   // If set, use a timer to progressively update the mesh.
   double update_mesh_every_n_sec = 0.0;
@@ -345,6 +340,12 @@ void Controller::subscribeSegmentPointCloudTopic(
       &Controller::segmentPointCloudCallback, this);
 }
 
+void Controller::advertiseMapTopic() {
+  map_cloud_pub_ = new ros::Publisher(
+      node_handle_private_->advertise<pcl::PointCloud<PointMapType>>("map", 1,
+                                                                     true));
+}
+
 void Controller::advertiseSceneMeshTopic() {
   scene_mesh_pub_ = new ros::Publisher(
       node_handle_private_->advertise<voxblox_msgs::Mesh>("mesh", 1, true));
@@ -373,6 +374,12 @@ void Controller::advertiseToggleIntegrationService(
   CHECK_NOTNULL(toggle_integration_srv);
   *toggle_integration_srv = node_handle_private_->advertiseService(
       "toggle_integration", &Controller::toggleIntegrationCallback, this);
+}
+
+void Controller::advertiseGetMapService(ros::ServiceServer* get_map_srv) {
+  CHECK_NOTNULL(get_map_srv);
+  *get_map_srv = node_handle_private_->advertiseService(
+      "get_map", &Controller::getMapCallback, this);
 }
 
 void Controller::advertiseGenerateMeshService(
@@ -660,6 +667,29 @@ bool Controller::toggleIntegrationCallback(
   return true;
 }
 
+bool Controller::getMapCallback(vpp_msgs::GetMap::Request& /* request */,
+                                vpp_msgs::GetMap::Response& response) {
+  pcl::PointCloud<PointMapType> map_pointcloud;
+
+  {
+    std::lock_guard<std::mutex> label_tsdf_layers_lock(
+        label_tsdf_layers_mutex_);
+    createPointcloudFromMap(*map_, &map_pointcloud);
+  }
+
+  map_pointcloud.header.frame_id = world_frame_;
+  pcl::toROSMsg(map_pointcloud, response.map_cloud);
+
+  response.voxels_per_side = map_config_.voxels_per_side;
+  response.voxel_size = map_config_.voxel_size;
+
+  if (publish_scene_map_) {
+    map_cloud_pub_->publish(map_pointcloud);
+  }
+
+  return true;
+}
+
 bool Controller::generateMeshCallback(std_srvs::Empty::Request& request,
                                       std_srvs::Empty::Response& response) {
   constexpr bool kClearMesh = true;
@@ -800,7 +830,7 @@ bool Controller::getAlignedInstanceBoundingBoxCallback(
   fillAlignedBoundingBoxMsg(bbox_translation, bbox_quaternion, bbox_size,
                             &response.bbox);
 
-  if (compute_and_publish_bbox_) {
+  if (publish_object_bbox_) {
     visualization_msgs::Marker bbox_marker;
     fillBoundingBoxMarkerMsg(world_frame_, instance_label, bbox_translation,
                              bbox_quaternion, bbox_size, &bbox_marker);
@@ -1054,9 +1084,8 @@ void Controller::computeAlignedBoundingBox(
   *bbox_translation = ((min_in_I + max_in_I) / 2).cast<float>();
   *bbox_size = ((oobb.m_maxPoint - oobb.m_minPoint).cwiseAbs()).cast<float>();
 #else
-  LOG(WARNING)
-      << "Bounding box computation is not supported since ApproxMVBB is "
-         "disabled.";
+  LOG(WARNING) << "ApproxMVBB is not available and therefore "
+                  "bounding box functionality is disabled.";
 #endif
 }
 

--- a/global_segment_map_node/src/node.cpp
+++ b/global_segment_map_node/src/node.cpp
@@ -33,14 +33,21 @@ int main(int argc, char** argv) {
   ros::Subscriber segment_point_cloud_sub;
   controller->subscribeSegmentPointCloudTopic(&segment_point_cloud_sub);
 
+  if (controller->publish_scene_map_) {
+    controller->advertiseMapTopic();
+  }
+
   if (controller->publish_scene_mesh_) {
     controller->advertiseSceneMeshTopic();
     controller->advertiseSceneCloudTopic();
   }
 
-  if (controller->compute_and_publish_bbox_) {
+  if (controller->publish_object_bbox_) {
     controller->advertiseBboxTopic();
   }
+
+  ros::ServiceServer get_map_srv;
+  controller->advertiseGetMapService(&get_map_srv);
 
   ros::ServiceServer generate_mesh_srv;
   controller->advertiseGenerateMeshService(&generate_mesh_srv);


### PR DESCRIPTION
Added a service `/get_map` to publish the reconstructed 3D map as a pointcloud. 
With this feature an effort in documenting the Voxblox++ node has begun under https://github.com/ethz-asl/voxblox-plusplus/wiki/The-voxblox-plusplus-node. Hopefully soon all the services, topics and subscriptions will be described there.

Note that any existing local Voxblox++ install will be able to use the new service only after pulling the `master` in https://github.com/ethz-asl/vpp_msgs

The service returns the 3D map pointcloud and the `voxel_size` needed to decode the map.

Each point in the pointcloud represents the center of a voxel in the map whose weight is higher than 0 (that is voxel is observed) and contains the following fields:
- XYZ the 3D position in world frame of the voxel center
- distance, i.e. the distance to the surface in the TSDF sense
- weight, i.e. the weight of the TSDF voxel
- segment label, the unique id of the segment
- semantic class, the id of the semantic category associated with the object (if any)

By setting the `publish_scene_map` param to true, the corresponding pointcloud is also published on the `/gsm_node/map` topic. 

Given the following reconstructed 3D scene:
![Screenshot from 2020-03-31 20-46-34](https://user-images.githubusercontent.com/2853614/78065602-d0483000-7393-11ea-9462-c1d28837e99a.png)

Here is how the said pointcloud looks in Rviz colored by the different fields:
- distance
![Screenshot from 2020-03-31 20-46-45](https://user-images.githubusercontent.com/2853614/78065649-e1913c80-7393-11ea-884c-ab764c7a71cd.png)

- weight 
![Screenshot from 2020-03-31 20-46-56](https://user-images.githubusercontent.com/2853614/78065662-e655f080-7393-11ea-826c-46785375b592.png)

- segment label
![Screenshot from 2020-03-31 20-47-08](https://user-images.githubusercontent.com/2853614/78065712-f5d53980-7393-11ea-860a-a2a959fc1620.png)

- semantic class
![Screenshot from 2020-03-31 20-47-19](https://user-images.githubusercontent.com/2853614/78065732-fb328400-7393-11ea-943d-0a14b047737c.png)

Plus refactored a couple of parameter names.
